### PR TITLE
Coursecompletion

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,54 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for block_course_summary.
+ *
+ * @package    block_course_template
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace coursecompletion\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy Subsystem for block_course_summary implementing null_provider.
+ *
+ * @copyright 	Catalyst IT {@link http://catalyst.net.nz}
+ * @author 	bO Pierce 
+ * @contributor Michael Nixon <michael.nixon@catalyst.net.nz>
+ * @license    	http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+    // This plugin does not store any personal user data.
+    use \core_privacy\local\legacy_polyfill;
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * This function is compatible with old php version.
+     * Diff is the underscore '_' in the beginning.
+     * But get_reason() still works 
+     * because of the trait legacy_polyfill.
+     *
+     * @return  string
+     */
+    public static function _get_reason() {
+        return 'privacy:no_userid_data';
+    }
+}

--- a/lang/en/report_coursecompletion.php
+++ b/lang/en/report_coursecompletion.php
@@ -51,5 +51,5 @@
     $string['form:operator_or'] = 'Any condition';
     $string['form:operator'] = 'Show records that match:';
 
-
-?>
+   // Privacy API.
+   $string['privacy:no_userid_data'] = 'The course completion plugin does not share data to external services, store user preferences, or identify users in its database.';

--- a/version.php
+++ b/version.php
@@ -1,7 +1,7 @@
 <?php
     defined("MOODLE_INTERNAL") || die;
 
-    $plugin->version = 2017102604;
+    $plugin->version = 2019030600;
     $plugin->requires = 2016052304.01;
     $plugin->component = "report_coursecompletion";
 ?>


### PR DESCRIPTION
mdl35 /report/coursecompletion - Added GDPR null provider class
with legacy_polyfill for PHP backward compatability.
In contrast, Moodle's privacy API doc uses a PHP7 example:
https://docs.moodle.org/dev/Privacy_API#Plugins_which_do_not_store_personal_data