### PR TITLE
Bug fix for syntax error when category and completion options selected.

### DIFF
--- a/index.php
+++ b/index.php
@@ -135,6 +135,7 @@ if ($data) {// Build the SQL query based on the form data.
     process_data_field($data, $where, $params, "c.fullname", "course", "LIKE");
 
     if (isset($data->completed_options)) {
+        $where .= !empty($where) ? " AND " : "";
         if ($data->completed_options == 1) {
             $where .= " cc.timecompleted IS NOT NULL";
         } else if ($data->completed_options == 2) {


### PR DESCRIPTION
There was an issue where if there was a where clause specified, in this case the category option selected, it did not include the "AND" in the clause which was causing a syntax error on the page.